### PR TITLE
Update the github link on top right of the page!

### DIFF
--- a/www/docusaurus.config.js
+++ b/www/docusaurus.config.js
@@ -73,7 +73,7 @@ const config = {
           },
           // {to: '/blog', label: 'Blog', position: 'left'},
           {
-            href: 'https://github.com/facebook/docusaurus',
+            href: 'https://github.com/0xs34n/starknet.js',
             label: 'GitHub',
             position: 'right',
           },


### PR DESCRIPTION
Currently that github page leads to https://github.com/facebook/docusaurus which is being replaced to https://github.com/0xs34n/starknet.js!